### PR TITLE
[2.x] Drop Laravel 8.x support (and PHP < 8) (#1082)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,13 +13,8 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [7.3, 7.4, '8.0', 8.1]
-        laravel: [8, 9]
-        exclude:
-          - php: 7.3
-            laravel: 9
-          - php: 7.4
-            laravel: 9
+        php: ['8.0', 8.1]
+        laravel: [9]
 
     name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }}
 

--- a/composer.json
+++ b/composer.json
@@ -14,9 +14,9 @@
         }
     ],
     "require": {
-        "php": "^7.3|^8.0",
+        "php": "^8.0.2",
         "ext-json": "*",
-        "illuminate/support": "^8.37|^9.0",
+        "illuminate/support": "^9.0",
         "jenssegers/agent": "^2.6",
         "laravel/fortify": "^1.12"
     },
@@ -26,6 +26,9 @@
         "mockery/mockery": "^1.0",
         "orchestra/testbench": "^6.0|^7.0",
         "phpunit/phpunit": "^9.3"
+    },
+    "conflict": {
+        "laravel/framework": "<9.19.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
* drop Laravel 8.x support (and PHP < 8)

* add composer conflict

* match current framework PHP version

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.

If you change the behavior of the Inertia stack you're expected to update the Livewire stack as well and vice versa.
-->
